### PR TITLE
Add support for tga

### DIFF
--- a/src/Extensions/ImageExtensions.cs
+++ b/src/Extensions/ImageExtensions.cs
@@ -28,6 +28,10 @@ namespace HarmonyTools.Extensions
                     image.SaveAsGif(stream);
                     break;
 
+                case "tga":
+                    image.SaveAsPng(stream);
+                    break;
+
                 default:
                     throw new ArgumentException($"Unknown extension '{extension}'");
             }


### PR DESCRIPTION
If SaveAsTga is used, the file will be saved without transparency